### PR TITLE
Encryption now expects terms to be pre-encoded

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,9 +99,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "generic-array"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -126,9 +126,9 @@ checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
 
 [[package]]
 name = "libloading"
@@ -281,7 +281,10 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "ore-encoding-rs"
 version = "0.1.0"
-source = "git+https://github.com/cipherstash/ore_encoding.rs#a1954938880634304f48c01d50d9c18649539fc9"
+source = "git+https://github.com/cipherstash/ore_encoding.rs#ec0f773bfae9d4e5540cf6499b021a43b3906945"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "ore-rs"
@@ -292,12 +295,13 @@ dependencies = [
  "ore-encoding-rs",
  "ore-rs 0.1.0 (git+https://github.com/cipherstash/ore.rs)",
  "quickcheck",
+ "unicode-normalization",
 ]
 
 [[package]]
 name = "ore-rs"
 version = "0.1.0"
-source = "git+https://github.com/cipherstash/ore.rs#53bea156a1587757a124fa5183e4b62f2ea193f6"
+source = "git+https://github.com/cipherstash/ore.rs#f7abeebede9ce890ed579c77078c6452ad6e679a"
 dependencies = [
  "aes",
  "block-modes",
@@ -310,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
@@ -336,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -451,16 +455,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
-name = "smallvec"
-version = "1.7.0"
+name = "siphasher"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "a86232ab60fa71287d7f2ddae4a7073f6b7aac33631c3015abb556f08c6d0a3e"
+
+[[package]]
+name = "smallvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "syn"
-version = "1.0.84"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -468,10 +478,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,11 +279,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "ore-encoding-rs"
+version = "0.1.0"
+source = "git+https://github.com/cipherstash/ore_encoding.rs#a1954938880634304f48c01d50d9c18649539fc9"
+
+[[package]]
 name = "ore-rs"
 version = "0.1.0"
 dependencies = [
  "hex-literal",
  "neon",
+ "ore-encoding-rs",
  "ore-rs 0.1.0 (git+https://github.com/cipherstash/ore.rs)",
  "quickcheck",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ path = "native/lib.rs"
 ore-rs = { git = "https://github.com/cipherstash/ore.rs" }
 ore-encoding-rs = { git = "https://github.com/cipherstash/ore_encoding.rs" }
 hex-literal = "0.3.2"
+unicode-normalization = "0.1.19"
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ path = "native/lib.rs"
 
 [dependencies]
 ore-rs = { git = "https://github.com/cipherstash/ore.rs" }
+ore-encoding-rs = { git = "https://github.com/cipherstash/ore_encoding.rs" }
 hex-literal = "0.3.2"
 
 [dev-dependencies]

--- a/native/lib.rs
+++ b/native/lib.rs
@@ -71,7 +71,7 @@ fn encrypt_num_left(mut cx: FunctionContext) -> JsResult<JsBuffer> {
 fn encrypt_buf(mut cx: FunctionContext) -> JsResult<JsBuffer> {
     let cipher = cx.argument::<BoxedCipher>(0)?;
     let ore = &mut *cipher.borrow_mut();
-    
+
     let result =
         fetch_plaintext_from_js_buffer::<8>(&mut cx, 1)?
         .encrypt(&mut ore.0)
@@ -133,10 +133,10 @@ fn fetch_plaintext_from_js_buffer<const N: usize>(cx: &mut FunctionContext, arg:
 
 #[neon::main]
 fn main(mut cx: ModuleContext) -> NeonResult<()> {
-    cx.export_function("encrypt_buf", encrypt_buf)?;
-    cx.export_function("encrypt_num", encrypt_num)?;
-    cx.export_function("encrypt_buf_left", encrypt_buf_left)?;
-    cx.export_function("encrypt_num_left", encrypt_num_left)?;
+    cx.export_function("encryptBuf", encrypt_buf)?;
+    cx.export_function("encryptNum", encrypt_num)?;
+    cx.export_function("encryptBufLeft", encrypt_buf_left)?;
+    cx.export_function("encryptNumLeft", encrypt_num_left)?;
     cx.export_function("initCipher", init)?;
     cx.export_function("compare", compare)?;
     Ok(())

--- a/native/lib.rs
+++ b/native/lib.rs
@@ -25,7 +25,7 @@ fn init(mut cx: FunctionContext) -> JsResult<BoxedCipher> {
             return Err("Invalid key length");
         }
         k.clone_from_slice(data.as_slice::<u8>());
-        return Ok(k);
+        Ok(k)
     };
 
     let k1 = cx.borrow(&arg0, clone_key).or_else(|e| cx.throw_error(e))?;
@@ -74,7 +74,7 @@ fn compare(mut cx: FunctionContext) -> JsResult<JsNumber> {
 
         cx.borrow(&b, |data_b| {
             let slice_b = data_b.as_slice::<u8>();
-            OREAES128::compare_raw_slices(&slice_a, &slice_b)
+            OREAES128::compare_raw_slices(slice_a, slice_b)
         })
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cipherstash/ore-rs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cipherstash/ore-rs",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "hasInstallScript": true,
       "license": "GPLv3",
       "devDependencies": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -21,14 +21,14 @@ describe("Init", () => {
 describe("Encrypt", () => {
   test("encrypt number", () => {
     let ore = ORE.init(k1, k2);
-    expect(ore.encrypt(ORE.encode(456)).length).toEqual(408);
+    expect(ore.encrypt(ORE.encodeNumber(456)).length).toEqual(408);
   })
 })
 
 describe("Encrypt Left", () => {
   test("encrypt number", () => {
     let ore = ORE.init(k1, k2);
-    expect(ore.encryptLeft(ORE.encode(456)).length).toEqual(136);
+    expect(ore.encryptLeft(ORE.encodeNumber(456)).length).toEqual(136);
   })
 })
 
@@ -39,8 +39,8 @@ describe("Compare (big-int)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(ORE.encode(456)),
-        ore.encrypt(ORE.encode(100))
+        ore.encrypt(ORE.encodeNumber(456)),
+        ore.encrypt(ORE.encodeNumber(100))
       )).toEqual(1);
   })
 
@@ -49,8 +49,8 @@ describe("Compare (big-int)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(ORE.encode(100)),
-        ore.encrypt(ORE.encode(788881001))
+        ore.encrypt(ORE.encodeNumber(100)),
+        ore.encrypt(ORE.encodeNumber(788881001))
       )).toEqual(-1);
   })
 
@@ -59,8 +59,8 @@ describe("Compare (big-int)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(ORE.encode(100888)),
-        ore.encrypt(ORE.encode(100888))
+        ore.encrypt(ORE.encodeNumber(100888)),
+        ore.encrypt(ORE.encodeNumber(100888))
       )).toEqual(0);
   })
 
@@ -69,8 +69,8 @@ describe("Compare (big-int)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(ORE.encode(0)),
-        ore.encrypt(ORE.encode(0))
+        ore.encrypt(ORE.encodeNumber(0)),
+        ore.encrypt(ORE.encodeNumber(0))
       )).toEqual(0);
   })
 })
@@ -81,8 +81,8 @@ describe("Compare (number)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(ORE.encode(456)),
-        ore.encrypt(ORE.encode(100))
+        ore.encrypt(ORE.encodeNumber(456)),
+        ore.encrypt(ORE.encodeNumber(100))
       )).toEqual(1);
   })
 
@@ -91,8 +91,8 @@ describe("Compare (number)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(ORE.encode(100)),
-        ore.encrypt(ORE.encode(788881001.75))
+        ore.encrypt(ORE.encodeNumber(100)),
+        ore.encrypt(ORE.encodeNumber(788881001.75))
       )).toEqual(-1);
   })
 
@@ -101,8 +101,8 @@ describe("Compare (number)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(ORE.encode(10088)),
-        ore.encrypt(ORE.encode(10088))
+        ore.encrypt(ORE.encodeNumber(10088)),
+        ore.encrypt(ORE.encodeNumber(10088))
       )).toEqual(0);
   })
 
@@ -111,8 +111,8 @@ describe("Compare (number)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(ORE.encode(0)),
-        ore.encrypt(ORE.encode(0))
+        ore.encrypt(ORE.encodeNumber(0)),
+        ore.encrypt(ORE.encodeNumber(0))
       )).toEqual(0);
   })
 
@@ -121,8 +121,8 @@ describe("Compare (number)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(ORE.encode(Number.MAX_SAFE_INTEGER)),
-        ore.encrypt(ORE.encode(Number.MAX_SAFE_INTEGER))
+        ore.encrypt(ORE.encodeNumber(Number.MAX_SAFE_INTEGER)),
+        ore.encrypt(ORE.encodeNumber(Number.MAX_SAFE_INTEGER))
       )).toEqual(0);
   })
 
@@ -131,8 +131,8 @@ describe("Compare (number)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(ORE.encode(800.3)),
-        ore.encrypt(ORE.encode(800.7))
+        ore.encrypt(ORE.encodeNumber(800.3)),
+        ore.encrypt(ORE.encodeNumber(800.7))
       )).toEqual(-1);
   })
 
@@ -141,8 +141,8 @@ describe("Compare (number)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(ORE.encode(80000.75)),
-        ore.encrypt(ORE.encode(800.0075))
+        ore.encrypt(ORE.encodeNumber(80000.75)),
+        ore.encrypt(ORE.encodeNumber(800.0075))
       )).toEqual(1);
   })
 
@@ -151,8 +151,8 @@ describe("Compare (number)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(ORE.encode(-800)),
-        ore.encrypt(ORE.encode(700))
+        ore.encrypt(ORE.encodeNumber(-800)),
+        ore.encrypt(ORE.encodeNumber(700))
       )).toEqual(-1);
   })
 
@@ -161,8 +161,8 @@ describe("Compare (number)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(ORE.encode(-800)),
-        ore.encrypt(ORE.encode(-900))
+        ore.encrypt(ORE.encodeNumber(-800)),
+        ore.encrypt(ORE.encodeNumber(-900))
       )).toEqual(1);
   })
 
@@ -171,8 +171,8 @@ describe("Compare (number)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(ORE.encode(-800.3)),
-        ore.encrypt(ORE.encode(-800.766))
+        ore.encrypt(ORE.encodeNumber(-800.3)),
+        ore.encrypt(ORE.encodeNumber(-800.766))
       )).toEqual(1);
   })
 
@@ -181,8 +181,17 @@ describe("Compare (number)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(ORE.encode(-80076.6)),
-        ore.encrypt(ORE.encode(-800.766))
+        ore.encrypt(ORE.encodeNumber(-80076.6)),
+        ore.encrypt(ORE.encodeNumber(-800.766))
       )).toEqual(-1);
+  })
+})
+
+describe("encodeString", () => {
+  test("different strings with same NFC form generate the same encoding", () => {
+    // See: https://unicode.org/reports/tr15/#Singletons_Figure
+    let s1 = '\u1E0A\u0323'
+    let s2 = '\u1E0C\u0307'
+    expect(ORE.encodeString(s1)).toEqual(ORE.encodeString(s2))
   })
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -19,52 +19,16 @@ describe("Init", () => {
 })
 
 describe("Encrypt", () => {
-  test("encrypt big int", () => {
-    let ore = ORE.init(k1, k2);
-    expect(ore.encrypt(456n).length).toEqual(408);
-  })
-
   test("encrypt number", () => {
     let ore = ORE.init(k1, k2);
-    expect(ore.encrypt(456).length).toEqual(408);
-  })
-
-  test("encrypt buffer", () => {
-    let ore = ORE.init(k1, k2);
-    let buf = Buffer.from([1, 1, 1, 1, 2, 2, 2, 2]);
-    expect(ore.encrypt(buf).length).toEqual(408);
-  })
-
-  test("invalid plaintext size", () => {
-    expect(() => {
-      let ore = ORE.init(k1, k2);
-      ore.encrypt(456942938989889898333322n);
-    }).toThrow(/out of range/)
+    expect(ore.encrypt(ORE.encode(456)).length).toEqual(408);
   })
 })
 
 describe("Encrypt Left", () => {
-  test("encrypt big int", () => {
-    let ore = ORE.init(k1, k2);
-    expect(ore.encryptLeft(456n).length).toEqual(136);
-  })
-
   test("encrypt number", () => {
     let ore = ORE.init(k1, k2);
-    expect(ore.encryptLeft(456).length).toEqual(136);
-  })
-
-  test("encrypt buffer", () => {
-    let ore = ORE.init(k1, k2);
-    let buf = Buffer.from([1, 1, 1, 1, 2, 2, 2, 2]);
-    expect(ore.encryptLeft(buf).length).toEqual(136);
-  })
-
-  test("invalid plaintext size", () => {
-    expect(() => {
-      let ore = ORE.init(k1, k2);
-      ore.encryptLeft(456942938989889898333322n);
-    }).toThrow(/out of range/)
+    expect(ore.encryptLeft(ORE.encode(456)).length).toEqual(136);
   })
 })
 
@@ -75,8 +39,8 @@ describe("Compare (big-int)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(456n),
-        ore.encrypt(100n)
+        ore.encrypt(ORE.encode(456)),
+        ore.encrypt(ORE.encode(100))
       )).toEqual(1);
   })
 
@@ -85,8 +49,8 @@ describe("Compare (big-int)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(100n),
-        ore.encrypt(788881001n)
+        ore.encrypt(ORE.encode(100)),
+        ore.encrypt(ORE.encode(788881001))
       )).toEqual(-1);
   })
 
@@ -95,8 +59,8 @@ describe("Compare (big-int)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(100888n),
-        ore.encrypt(100888n)
+        ore.encrypt(ORE.encode(100888)),
+        ore.encrypt(ORE.encode(100888))
       )).toEqual(0);
   })
 
@@ -105,19 +69,8 @@ describe("Compare (big-int)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(0n),
-        ore.encrypt(0n)
-      )).toEqual(0);
-  })
-
-  test("compare equal 64-bit max", () => {
-    let ore = ORE.init(k1, k2);
-    let max = 2n ** 64n - 1n;
-
-    expect(
-      ORE.compare(
-        ore.encrypt(max),
-        ore.encrypt(max)
+        ore.encrypt(ORE.encode(0)),
+        ore.encrypt(ORE.encode(0))
       )).toEqual(0);
   })
 })
@@ -128,8 +81,8 @@ describe("Compare (number)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(456),
-        ore.encrypt(100)
+        ore.encrypt(ORE.encode(456)),
+        ore.encrypt(ORE.encode(100))
       )).toEqual(1);
   })
 
@@ -138,8 +91,8 @@ describe("Compare (number)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(100),
-        ore.encrypt(788881001.75)
+        ore.encrypt(ORE.encode(100)),
+        ore.encrypt(ORE.encode(788881001.75))
       )).toEqual(-1);
   })
 
@@ -148,8 +101,8 @@ describe("Compare (number)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(10088),
-        ore.encrypt(10088)
+        ore.encrypt(ORE.encode(10088)),
+        ore.encrypt(ORE.encode(10088))
       )).toEqual(0);
   })
 
@@ -158,8 +111,8 @@ describe("Compare (number)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(0),
-        ore.encrypt(0)
+        ore.encrypt(ORE.encode(0)),
+        ore.encrypt(ORE.encode(0))
       )).toEqual(0);
   })
 
@@ -168,8 +121,8 @@ describe("Compare (number)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(Number.MAX_SAFE_INTEGER),
-        ore.encrypt(Number.MAX_SAFE_INTEGER)
+        ore.encrypt(ORE.encode(Number.MAX_SAFE_INTEGER)),
+        ore.encrypt(ORE.encode(Number.MAX_SAFE_INTEGER))
       )).toEqual(0);
   })
 
@@ -178,8 +131,8 @@ describe("Compare (number)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(800.3),
-        ore.encrypt(800.7)
+        ore.encrypt(ORE.encode(800.3)),
+        ore.encrypt(ORE.encode(800.7))
       )).toEqual(-1);
   })
 
@@ -188,8 +141,8 @@ describe("Compare (number)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(80000.75),
-        ore.encrypt(800.0075)
+        ore.encrypt(ORE.encode(80000.75)),
+        ore.encrypt(ORE.encode(800.0075))
       )).toEqual(1);
   })
 
@@ -198,8 +151,8 @@ describe("Compare (number)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(-800),
-        ore.encrypt(700)
+        ore.encrypt(ORE.encode(-800)),
+        ore.encrypt(ORE.encode(700))
       )).toEqual(-1);
   })
 
@@ -208,8 +161,8 @@ describe("Compare (number)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(-800),
-        ore.encrypt(-900)
+        ore.encrypt(ORE.encode(-800)),
+        ore.encrypt(ORE.encode(-900))
       )).toEqual(1);
   })
 
@@ -218,8 +171,8 @@ describe("Compare (number)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(-800.3),
-        ore.encrypt(-800.766)
+        ore.encrypt(ORE.encode(-800.3)),
+        ore.encrypt(ORE.encode(-800.766))
       )).toEqual(1);
   })
 
@@ -228,8 +181,8 @@ describe("Compare (number)", () => {
 
     expect(
       ORE.compare(
-        ore.encrypt(-80076.6),
-        ore.encrypt(-800.766)
+        ore.encrypt(ORE.encode(-80076.6)),
+        ore.encrypt(ORE.encode(-800.766))
       )).toEqual(-1);
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,10 @@
 /* Importing the rust compiled lib (index.node) doesn't work and so we use require here */
 const {
   initCipher,
-  encrypt_buf,
-  encrypt_num,
-  encrypt_buf_left,
-  encrypt_num_left,
+  encryptBuf,
+  encryptNum,
+  encryptBufLeft,
+  encryptNumLeft,
   compare
 } = require("../index.node");
 
@@ -25,7 +25,7 @@ export const ORE = {
   init: (k1: Key, k2: Key): ORECipher => {
     let cipher = initCipher(k1, k2);
     return {
-      /* 
+      /*
        * Encrypt the given `PlainText` outputting a "full" CipherText (i.e. a `Buffer`
        * containing both the Left and Right components).
        */
@@ -34,15 +34,15 @@ export const ORE = {
           // Neon doesn't support Bigint so we do this here
           let buf = Buffer.allocUnsafe(8);
           buf.writeBigUInt64BE(input);
-          return encrypt_buf(cipher, buf);
+          return encryptBuf(cipher, buf);
         } else if (input instanceof Buffer) {
-          return encrypt_buf(cipher, input);
+          return encryptBuf(cipher, input);
         } else {
-          return encrypt_num(cipher, input);
+          return encryptNum(cipher, input);
         }
       },
 
-      /* 
+      /*
        * Encrypt the given `PlainText` outputting only a Left CipherText (i.e. a `Buffer`
        * containing just the Left component).
        */
@@ -51,11 +51,11 @@ export const ORE = {
           // Neon doesn't support Bigint so we do this here
           let buf = Buffer.allocUnsafe(8);
           buf.writeBigUInt64BE(input);
-          return encrypt_buf_left(cipher, buf);
+          return encryptBufLeft(cipher, buf);
         } else if (input instanceof Buffer) {
-          return encrypt_buf_left(cipher, input);
+          return encryptBufLeft(cipher, input);
         } else {
-          return encrypt_num_left(cipher, input);
+          return encryptNumLeft(cipher, input);
         }
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,32 +1,34 @@
-"use strict";
-
 /* Importing the rust compiled lib (index.node) doesn't work and so we use require here */
 const {
   initCipher,
-  encryptNum,
-  encryptNumLeft,
+  encrypt,
+  encryptLeft,
   compare,
-  encodeNum
-} = require("../index.node");
+  encodeNumber,
+  encodeString
+} = require("../index.node")
 
-export type Key = Buffer;
-export type PlainText = number
-export type CipherText = Buffer;
+export type Key = Buffer
+export type CipherText = Buffer
 
 export type ORECipher = {
-  encrypt: (input: PlainText) => CipherText,
-  encryptLeft: (input: PlainText) => CipherText
+  encrypt: (input: number) => CipherText,
+  encryptLeft: (input: number) => CipherText
 }
 
 export type Ordering = -1 | 0 | 1
 
 export interface ORE {
-  encode: (input: PlainText) => PlainText
+  encodeString: (input: string) => number
+  encodeNumber: (input: number) => number
   init: (k1: Key, k2: Key) => ORECipher
   compare: (a: CipherText, b: CipherText) => Ordering
 }
 
-/* Module to perform Order-revealing Encryption using the underlying ore.rs Rust library */
+/**
+ * Module to perform Order-revealing Encryption using the underlying ore.rs Rust
+ * library.
+ */
 export const ORE: ORE = {
 
   /**
@@ -38,29 +40,45 @@ export const ORE: ORE = {
    * @param input the JS number to encode
    * @returns a JS number that can be encrypted with the ORE scheme
    */
-  encode: encodeNum,
+  encodeNumber,
 
-  /* Initialize a new ORE cipher with a key pair (both keys must be 16-byte buffers). */
+  /**
+   * Converts a string to a ORE-compatible plaintext (a JS number). The number
+   * is the siphash of the string.
+   *
+   * Ciphertexts made from the plaintext can only be meaningfully checked for
+   * equality. In the medium term we will use an  equality revealing scheme for
+   * strings.
+   *
+   * @param input the JS number to encode
+   * @returns a JS number that can be encrypted with the ORE scheme
+   */
+  encodeString,
+
+  /**
+   * Initialize a new ORE cipher with a key pair (both keys must be 16-byte
+   * buffers)
+   */
   init: (k1: Key, k2: Key): ORECipher => {
     let cipher = initCipher(k1, k2);
     return {
       /*
-       * Encrypt the given `PlainText` outputting a "full" CipherText (i.e. a `Buffer`
-       * containing both the Left and Right components).
+       * Encrypt the given `PlainText` outputting a "full" CipherText (i.e. a
+       * `Buffer` containing both the Left and Right components).
        */
-      encrypt: (input: PlainText): CipherText => encryptNum(cipher, input),
+      encrypt: (input: number): CipherText => encrypt(cipher, input),
 
       /*
-       * Encrypt the given `PlainText` outputting only a Left CipherText (i.e. a `Buffer`
-       * containing just the Left component).
+       * Encrypt the given `PlainText` outputting only a Left CipherText (i.e. a
+       * `Buffer` containing just the Left component).
        */
-      encryptLeft: (input: PlainText): CipherText => encryptNumLeft(cipher, input)
+      encryptLeft: (input: number): CipherText => encryptLeft(cipher, input)
     }
   },
 
   /*
-   * Compare two cipher texts returning -1 if a < b, 0 if a === b, and 1 if a > b.
-   * Throws if the inputs are not comparable.
+   * Compare two cipher texts returning -1 if a < b, 0 if a === b, and 1 if a >
+   * b.  Throws if the inputs are not comparable.
    */
   compare: (a: CipherText, b: CipherText): Ordering => compare(a, b)
-};
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,8 +18,16 @@ export type ORECipher = {
   encryptLeft: (input: PlainText) => CipherText
 }
 
+export type Ordering = -1 | 0 | 1
+
+export interface ORE {
+  encode: (input: PlainText) => PlainText
+  init: (k1: Key, k2: Key) => ORECipher
+  compare: (a: CipherText, b: CipherText) => Ordering
+}
+
 /* Module to perform Order-revealing Encryption using the underlying ore.rs Rust library */
-export const ORE = {
+export const ORE: ORE = {
 
   /**
    * Prepares a plaintext (a JS number AKA f64) for ORE encryption by converting
@@ -54,7 +62,5 @@ export const ORE = {
    * Compare two cipher texts returning -1 if a < b, 0 if a === b, and 1 if a > b.
    * Throws if the inputs are not comparable.
    */
-  compare: (a: CipherText, b: CipherText): any => { // TODO: Enum integer type
-    return compare(a, b);
-  }
+  compare: (a: CipherText, b: CipherText): Ordering => compare(a, b)
 };


### PR DESCRIPTION
- add dependency on ore_encoding.rs
- only accept JSNumber as arg to encrypt function
- assume arg is pre-encoded
- update tests to encode terms before encryption
- export ORE.encodeNumber(n) function
- export ORE.encodeString(s) function (performs unicode normalisation and then siphash's)