### PR TITLE
Pass plaintexts around as buffers

### DIFF
--- a/native/lib.rs
+++ b/native/lib.rs
@@ -68,10 +68,7 @@ fn encrypt_left(mut cx: FunctionContext) -> JsResult<JsBuffer> {
     let cipher = cx.argument::<BoxedCipher>(0)?;
     let ore = &mut *cipher.borrow_mut();
     let arg = cx.argument::<JsBuffer>(1)?;
-    let input: u64 = match u64_from_buffer(&cx, arg) {
-        Ok(u) => u,
-        Err(e) => return cx.throw_error(e)
-    };
+    let input: u64 = u64_from_buffer(&cx, arg).or_else(|e| return cx.throw_error(e))?;
 
     let result = input
         .encrypt_left(&mut ore.0)

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -18,6 +18,12 @@ describe("Init", () => {
   })
 })
 
+describe("encode number", () => {
+  test("0", () => {
+    expect(ORE.encode(0)).toEqual(Buffer.from([0, 0, 0, 0, 0, 0, 0, 0x80]));
+  })
+})
+
 describe("Encrypt", () => {
   test("encrypt number", () => {
     let ore = ORE.init(k1, k2);
@@ -198,6 +204,6 @@ describe("encodeString", () => {
 
 describe("encodeRangeBetween", () => {
   test('correct min and max generated in range', () => {
-    expect(ORE.encodeRangeBetween(1, 100)).toEqual({ min: 1, max: 100})
+    expect(ORE.encodeRangeBetween(1, 100)).toEqual({ min: ORE.encode(1), max: ORE.encode(100)})
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ const {
 
 export type Key = Buffer
 export type CipherText = Buffer
-export type OrePlainText = number
+export type OrePlainText = Buffer
 export type OreRange = { min: OrePlainText, max: OrePlainText }
 
 export type ORECipher = {
@@ -25,13 +25,13 @@ export type ORECipher = {
    * Encrypt the given `PlainText` outputting a "full" CipherText (i.e. a
    * `Buffer` containing both the Left and Right components).
    */
-  encrypt: (input: number) => CipherText,
+  encrypt: (input: OrePlainText) => CipherText,
 
   /*
    * Encrypt the given `PlainText` outputting only a Left CipherText (i.e. a
    * `Buffer` containing just the Left component).
    */
-  encryptLeft: (input: number) => CipherText
+  encryptLeft: (input: OrePlainText) => CipherText
 }
 
 export type Ordering = -1 | 0 | 1
@@ -73,12 +73,12 @@ export interface ORE {
   encode: (input: number | Buffer | string) => OrePlainText
 
 
-  encodeRangeLt: (value: OrePlainText) => OreRange
-  encodeRangeLte: (value: OrePlainText) => OreRange
-  encodeRangeGt: (value: OrePlainText) => OreRange
-  encodeRangeGte: (value: OrePlainText) => OreRange
-  encodeRangeEq: (value: OrePlainText) => OreRange
-  encodeRangeBetween: (min: OrePlainText, max: OrePlainText) => OreRange
+  encodeRangeLt: (value: number) => OreRange
+  encodeRangeLte: (value: number) => OreRange
+  encodeRangeGt: (value: number) => OreRange
+  encodeRangeGte: (value: number) => OreRange
+  encodeRangeEq: (value: number) => OreRange
+  encodeRangeBetween: (min: number, max: number) => OreRange
 
   /**
    * Initialize a new ORE cipher with a key pair (both keys must be 16-byte
@@ -119,13 +119,12 @@ export const ORE: ORE = {
   encodeRangeLt,
   encodeRangeLte,
 
-
   init: (k1: Key, k2: Key): ORECipher => {
     let cipher = initCipher(k1, k2);
     return {
-      encrypt: (input: number): CipherText => encrypt(cipher, input),
+      encrypt: (input: OrePlainText): CipherText => encrypt(cipher, input),
 
-      encryptLeft: (input: number): CipherText => encryptLeft(cipher, input)
+      encryptLeft: (input: OrePlainText): CipherText => encryptLeft(cipher, input)
     }
   },
 


### PR DESCRIPTION
This prevents any possible unpleasantnesses caused by passing numbers around
inside the JavaScript interpreter.  Also tightened up some of the types
exported, so that it's a (bit) harder to accidentally make ranges out of an
unencoded value, or double-encode a value.