### PR TITLE
Ensure correct deps for installation

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
-nodejs 16.13.1
+nodejs 16.14.0
 rust 1.56.1
+pnpm 6.26.0

--- a/package.json
+++ b/package.json
@@ -39,13 +39,15 @@
     "stash"
   ],
   "license": "GPLv3",
+  "dependencies": {
+    "cargo-cp-artifact": "^0.1"
+  },
   "devDependencies": {
     "@babel/core": "^7.16.5",
     "@babel/preset-env": "^7.16.5",
     "@babel/preset-typescript": "^7.16.5",
     "@types/jest": "^27.0.3",
     "@types/node": "^17.0.4",
-    "cargo-cp-artifact": "^0.1",
     "ts-node": "^10.4.0",
     "typescript": "^4.5.4"
   },


### PR DESCRIPTION
Moved `cargo-cp-artifact` to deps (not just dev) so that installs don't fail.