### PR TITLE
Add indexer, change to `@cipherstash/stash-rs`

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 nodejs 16.14.0
-rust 1.56.1
+rust 1.59.0
 pnpm 6.26.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,12 +58,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "ciborium"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "cipherstash-client"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f15019e4dfa895578767bf6c8a99920f3ba3c8a564af055911545a7dd1523936"
+dependencies = [
+ "ciborium",
+ "conv",
+ "hex-literal",
+ "minicbor",
+ "ore-encoding-rs",
+ "ore-rs",
+ "serde",
+ "serde_bytes",
+ "thiserror",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "conv"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
+dependencies = [
+ "custom_derive",
 ]
 
 [[package]]
@@ -80,6 +134,12 @@ name = "cslice"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "697c714f50560202b1f4e2e09cd50a421881c83e9025db75d15f276616f04f40"
+
+[[package]]
+name = "custom_derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 
 [[package]]
 name = "env_logger"
@@ -119,6 +179,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "hex-literal"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,6 +220,15 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "minicbor"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b419e66bd98ccf5824dd4b8f4141f7431d1d07733c3e13c946278204a437d2b"
+dependencies = [
+ "half",
+]
 
 [[package]]
 name = "neon"
@@ -280,8 +355,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "ore-encoding-rs"
-version = "0.23.2"
-source = "git+https://github.com/cipherstash/ore_encoding.rs?tag=0.23.2#d704ca9cae6f9236357e9b320e13b82f0d8f4612"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "828aa5f4f8eb04ce2ddf4b34c166ada44d8b1718191f8f5c863cf57143fd16c2"
 dependencies = [
  "num",
  "siphasher",
@@ -289,8 +365,9 @@ dependencies = [
 
 [[package]]
 name = "ore-rs"
-version = "0.1.0"
-source = "git+https://github.com/cipherstash/ore.rs#f7abeebede9ce890ed579c77078c6452ad6e679a"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b5f6efbcad962a82bd2ec10cd2d2d32f2bc9e8bfc82a7dee6a88a66c3453136"
 dependencies = [
  "aes",
  "block-modes",
@@ -299,18 +376,6 @@ dependencies = [
  "num",
  "rand 0.3.23",
  "rand_chacha",
-]
-
-[[package]]
-name = "ore-rs"
-version = "0.4.6"
-dependencies = [
- "hex-literal",
- "neon",
- "ore-encoding-rs",
- "ore-rs 0.1.0",
- "quickcheck",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -456,6 +521,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
+name = "serde"
+version = "1.0.137"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212e73464ebcde48d723aa02eb270ba62eff38a9b732df31f33f1b4e145f3a54"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.137"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,14 +562,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
+name = "stash-rs"
+version = "0.4.6"
+dependencies = [
+ "cipherstash-client",
+ "hex-literal",
+ "neon",
+ "ore-encoding-rs",
+ "ore-rs",
+ "quickcheck",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "syn"
-version = "1.0.86"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "04066589568b72ec65f42d65a1a52436e954b168773148893c020269563decf2"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ore-rs"
+name = "stash-rs"
 version = "0.4.6"
 description = "Node bindings for ore.rs"
 license = "ISC"
@@ -13,8 +13,9 @@ path = "native/lib.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ore-rs = { git = "https://github.com/cipherstash/ore.rs" }
-ore-encoding-rs = { git = "https://github.com/cipherstash/ore_encoding.rs", tag = "0.23.2" }
+cipherstash-client = "0.1.0"
+ore-rs = "0.2.0"
+ore-encoding-rs = "0.23.2"
 hex-literal = "0.3.2"
 unicode-normalization = "0.1.19"
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,49 @@ let s2 = cipher.encrypt(ORE.encodeString("Hello from CipherStash!")) // OK
 ORE.compare(s1, s2) // => 0
 ```
 
+## RecordIndexer
+
+The record indexer can perform a variety of ORE operations on JavaScript objects based on a [specified schema](https://docs.cipherstash.com/reference/schema-definition.html).
+The "terms" returned by the indexer can be used to create a searchable encrypted database index like [CipherStash](https://cipherstash.com).
+
+### Encrypt
+
+```typescript
+const indexer = RecordIndexer.init({
+  type: {
+    title: "string",
+    runningTime: "uint64"
+  },
+  indexes: {
+    exactTitle: {
+      mapping: { kind: "exact", field: "title" },
+      index_id: makeId(),
+      prf_key: <Buffer ..>
+      prp_key: <Buffer ..>
+    },
+    title: {
+      mapping: {
+        kind: "match",
+        fields: ["title"],
+        tokenFilters: [{ kind: "downcase" }],
+        tokenizer: { kind: "ngram", tokenLength: 3 }
+      },
+      index_id: makeId(),
+      prf_key: <Buffer ..>
+      prp_key: <Buffer ..>
+    }
+  }
+})
+
+// The returned terms contain the ORE ciphertext for the "match" and "exact" indexes defined
+// in the schema.
+const terms = indexer.encrypt({
+  id: makeId(),
+  title: "Great movie!",
+  runningTime: 120
+})
+```
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# ore-rs
+# @cipherstash/stash-rs
 
-**ore-rs:** Node bindings for [ore.rs](https://github.com/cipherstash/ore.rs).
+This project includes Node bindings for [ore.rs](https://github.com/cipherstash/ore.rs) and [cipherstash-client](https://github.com/cipherstash/cipherstash-rs).
 
 This project was bootstrapped by [create-neon](https://www.npmjs.com/package/create-neon).
 
-## Installing ore-rs
+## Installing stash-rs
 
-Installing ore-rs requires a [supported version of Node and Rust](https://github.com/neon-bindings/neon#platform-support).
+Installing stash-rs requires a [supported version of Node and Rust](https://github.com/neon-bindings/neon#platform-support).
 
 You can install the project with npm. In the project directory, run:
 
@@ -16,7 +16,7 @@ $ npm install
 
 This fully installs the project, including installing any dependencies and running the build.
 
-## Building ore-rs
+## Building stash-rs
 
 If you have already installed the project and only want to run the build, run:
 
@@ -29,15 +29,14 @@ This command performs 2 steps:
 1. It uses the [cargo-cp-artifact](https://github.com/neon-bindings/cargo-cp-artifact) utility to run the Rust build and copy the built library into `./index.node`.
 2. It compiles the TypeScript code (in `src/index.ts`) with the output being stored in `dist`
 
-## Exploring ore-rs
+## Exploring stash-rs
 
-After building ore-rs, you can explore its exports at the TS Node REPL:
+After building stash-rs, you can explore its exports at the TS Node REPL.
 
 ```sh
 $ npm install
 $ npx ts-node
-> const ORE = require('.')
-> import { ORE } from '@cipherstash/ore-rs'
+> import { ORE } from '@cipherstash/stash-rs'
 > let k1 = Buffer.from("1216a6700004fe46c5c07166025e681e", "hex")
 > let k2 = Buffer.from("3f13a569d5d2c6ce8d2a85cb9e347804", "hex")
 > let cipher = new ORE(k1, k2)
@@ -45,7 +44,9 @@ $ npx ts-node
 > cipher.encrypt(ORE.encodeNumber(100))
 ```
 
-## Comparison
+## ORE
+
+### Comparison
 
 To compare two encrypted ciphertext values, you can use the `ORE.compare` function which returns -1, 0 or 1 if the first
 operand is less-than, equal-to or greater than the second operand respectively.
@@ -58,11 +59,11 @@ let b = ore.encrypt(ORE.encodeNumber(1560))
 ORE.compare(a, b) // => -1
 ```
 
-## Data Types
+### Data Types
 
-`ore-rs` can encrypt the following types:
+`ORE` can encrypt the following types:
 
-### Number
+#### Number
 
 JavaScript numbers are 64-bit floats which the underlying ORE library converts into an order-preserving integer. The
 underlying value no longer represents the source number (unlike `f64::from(i)`) but guarantees ordering is preserved.
@@ -74,7 +75,7 @@ cipher.encrypt(ORE.encodeNumber(3.14159))
 cipher.encrypt(ORE.encodeNumber(-100))
 ```
 
-### String
+#### String
 
 `ORE.encodeString` performs unicode normalisation (NFC) on the input string, then hashes the result using siphash.
 The resulting number can be encrypted. However, because strings are hashed only equality comparisons make sense.
@@ -120,7 +121,7 @@ Runs the unit tests in Rust by calling `cargo test` and in TypeScript (Jest) by 
 The directory structure of this project is:
 
 ```
-ore-rs/
+node-stash-rs/
 ├── Cargo.toml
 ├── README.md
 ├── index.node

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,24 @@
 {
-  "name": "@cipherstash/ore-rs",
-  "version": "0.1.1",
+  "name": "@cipherstash/stash-rs",
+  "version": "0.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@cipherstash/ore-rs",
-      "version": "0.1.1",
+      "name": "@cipherstash/stash-rs",
+      "version": "0.5.1",
       "hasInstallScript": true,
       "license": "GPLv3",
+      "dependencies": {
+        "cargo-cp-artifact": "^0.1",
+        "cbor": "^8.1.0"
+      },
       "devDependencies": {
         "@babel/core": "^7.16.5",
         "@babel/preset-env": "^7.16.5",
         "@babel/preset-typescript": "^7.16.5",
         "@types/jest": "^27.0.3",
         "@types/node": "^17.0.4",
-        "cargo-cp-artifact": "^0.1",
         "ts-node": "^10.4.0",
         "typescript": "^4.5.4"
       }
@@ -1956,9 +1959,19 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/cargo-cp-artifact/-/cargo-cp-artifact-0.1.6.tgz",
       "integrity": "sha512-CQw0doK/aaF7j041666XzuilHxqMxaKkn+I5vmBsd8SAwS0cO5CqVEVp0xJwOKstyqWZ6WK4Ww3O6p26x/Goyg==",
-      "dev": true,
       "bin": {
         "cargo-cp-artifact": "bin/cargo-cp-artifact.js"
+      }
+    },
+    "node_modules/cbor": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-8.1.0.tgz",
+      "integrity": "sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==",
+      "dependencies": {
+        "nofilter": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12.19"
       }
     },
     "node_modules/chalk": {
@@ -2347,6 +2360,14 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
       "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
       "dev": true
+    },
+    "node_modules/nofilter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
+      "integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==",
+      "engines": {
+        "node": ">=12.19"
+      }
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
@@ -4033,8 +4054,15 @@
     "cargo-cp-artifact": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/cargo-cp-artifact/-/cargo-cp-artifact-0.1.6.tgz",
-      "integrity": "sha512-CQw0doK/aaF7j041666XzuilHxqMxaKkn+I5vmBsd8SAwS0cO5CqVEVp0xJwOKstyqWZ6WK4Ww3O6p26x/Goyg==",
-      "dev": true
+      "integrity": "sha512-CQw0doK/aaF7j041666XzuilHxqMxaKkn+I5vmBsd8SAwS0cO5CqVEVp0xJwOKstyqWZ6WK4Ww3O6p26x/Goyg=="
+    },
+    "cbor": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-8.1.0.tgz",
+      "integrity": "sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==",
+      "requires": {
+        "nofilter": "^3.1.0"
+      }
     },
     "chalk": {
       "version": "2.4.2",
@@ -4327,6 +4355,11 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
       "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
       "dev": true
+    },
+    "nofilter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
+      "integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g=="
     },
     "object-keys": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@cipherstash/ore-rs",
-  "version": "0.5.1",
-  "description": "Node bindings for ore.rs",
+  "name": "@cipherstash/stash-rs",
+  "version": "0.1.0",
+  "description": "Node bindings for the CipherStash Rust client.",
   "main": "dist/index.js",
   "scripts": {
     "build": "npx cargo-cp-artifact -nc index.node -- cargo build --message-format=json-render-diagnostics && npx tsc",
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cipherstash/node-ore-rs.git"
+    "url": "git+https://github.com/cipherstash/node-stash-rs.git"
   },
   "publishConfig": {
     "access": "public",
@@ -40,7 +40,8 @@
   ],
   "license": "GPLv3",
   "dependencies": {
-    "cargo-cp-artifact": "^0.1"
+    "cargo-cp-artifact": "^0.1",
+    "cbor": "^8.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.5",
@@ -59,6 +60,7 @@
       "d.ts",
       "json"
     ],
+    "testEnvironment": "node",
     "testMatch": [
       "**/*.test.ts"
     ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,8 @@ export type CipherText = Buffer
 export type OrePlainText = Buffer
 export type OreRange = { min: OrePlainText, max: OrePlainText }
 
+export * from './record-indexer';
+
 export type ORECipher = {
   /*
    * Encrypt the given `PlainText` outputting a "full" CipherText (i.e. a

--- a/src/record-indexer.test.ts
+++ b/src/record-indexer.test.ts
@@ -1,0 +1,141 @@
+import { RecordIndexer } from "./record-indexer"
+
+const prf_key = Buffer.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+
+const prp_key = Buffer.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+
+const index_id = Buffer.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+
+const record_id = Buffer.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+
+describe("RecordIndexer", () => {
+  describe("init", () => {
+    test("load from schema", () => {
+      expect(() =>
+        RecordIndexer.init({
+          type: {
+            title: "string",
+            runningTime: "uint64",
+          },
+          indexes: {
+            exactTitle: {
+              mapping: { kind: "exact", field: "title" },
+              index_id,
+              prf_key,
+              prp_key,
+            },
+          },
+        })
+      ).not.toThrow()
+    })
+
+    test("invalid key in schema", () => {
+      expect(() =>
+        RecordIndexer.init({
+          type: {
+            title: "string",
+            runningTime: "uint64",
+          },
+          indexes: {
+            exactTitle: {
+              mapping: { kind: "exact", field: "title" },
+              index_id,
+              prf_key: Buffer.from([1, 2]),
+              prp_key,
+            },
+          },
+        })
+      ).toThrow(/invalid length 2/)
+    })
+
+    test("invalid index_id in schema", () => {
+      expect(() =>
+        RecordIndexer.init({
+          type: {
+            title: "string",
+            runningTime: "uint64",
+          },
+          indexes: {
+            exactTitle: {
+              mapping: { kind: "exact", field: "title" },
+              index_id: Buffer.from([1, 2, 3, 4]),
+              prf_key,
+              prp_key,
+            },
+          },
+        })
+      ).toThrow(/invalid length 4/)
+    })
+  })
+
+  test("index record", () => {
+    const indexer = RecordIndexer.init({
+      type: {
+        title: "string",
+        runningTime: "uint64",
+      },
+      indexes: {
+        exactTitle: {
+          mapping: { kind: "exact", field: "title" },
+          index_id,
+          prf_key,
+          prp_key,
+        },
+      },
+    })
+
+    const vectors = indexer.encryptRecord({
+      id: record_id,
+      title: "What a great title!",
+    })
+
+    expect(vectors).toHaveLength(1)
+  })
+
+  test("index record empty record", () => {
+    const indexer = RecordIndexer.init({
+      type: {
+        title: "string",
+        runningTime: "uint64",
+      },
+      indexes: {
+        exactTitle: {
+          mapping: { kind: "exact", field: "title" },
+          index_id,
+          prf_key,
+          prp_key,
+        },
+      },
+    })
+
+    const vectors = indexer.encryptRecord({
+      id: record_id,
+    })
+
+    expect(vectors).toHaveLength(0)
+  })
+
+  test("index record with Uint8Array id", () => {
+    const indexer = RecordIndexer.init({
+      type: {
+        title: "string",
+        runningTime: "uint64",
+      },
+      indexes: {
+        exactTitle: {
+          mapping: { kind: "exact", field: "title" },
+          index_id,
+          prf_key,
+          prp_key,
+        },
+      },
+    })
+
+    const vectors = indexer.encryptRecord({
+      id: new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+      title: "Great title!",
+    });
+
+    expect(vectors).toHaveLength(1)
+  })
+})

--- a/src/record-indexer.test.ts
+++ b/src/record-indexer.test.ts
@@ -9,6 +9,8 @@ const index_id = Buffer.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 
 const record_id = Buffer.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 
 describe("RecordIndexer", () => {
+
+
   describe("init", () => {
     test("load from schema", () => {
       expect(() =>
@@ -68,8 +70,10 @@ describe("RecordIndexer", () => {
     })
   })
 
-  test("index record", () => {
-    const indexer = RecordIndexer.init({
+  let indexer: RecordIndexer
+
+  beforeEach(() => {
+    indexer = RecordIndexer.init({
       type: {
         title: "string",
         runningTime: "uint64",
@@ -83,7 +87,9 @@ describe("RecordIndexer", () => {
         },
       },
     })
+  })
 
+  test("index record", () => {
     const vectors = indexer.encryptRecord({
       id: record_id,
       title: "What a great title!",
@@ -93,21 +99,6 @@ describe("RecordIndexer", () => {
   })
 
   test("index record empty record", () => {
-    const indexer = RecordIndexer.init({
-      type: {
-        title: "string",
-        runningTime: "uint64",
-      },
-      indexes: {
-        exactTitle: {
-          mapping: { kind: "exact", field: "title" },
-          index_id,
-          prf_key,
-          prp_key,
-        },
-      },
-    })
-
     const vectors = indexer.encryptRecord({
       id: record_id,
     })
@@ -115,26 +106,25 @@ describe("RecordIndexer", () => {
     expect(vectors).toHaveLength(0)
   })
 
-  test("index record with Uint8Array id", () => {
-    const indexer = RecordIndexer.init({
-      type: {
-        title: "string",
-        runningTime: "uint64",
-      },
-      indexes: {
-        exactTitle: {
-          mapping: { kind: "exact", field: "title" },
-          index_id,
-          prf_key,
-          prp_key,
-        },
-      },
+  test("index record null fields", () => {
+    const vectors = indexer.encryptRecord({
+      id: record_id,
+      title: null,
+      runningTime: undefined
     })
 
+    expect(vectors).toHaveLength(0)
+  })
+
+  test("index record must have id", () => {
+    expect(() => indexer.encryptRecord(null as any)).toThrow()
+  })
+
+  test("index record with Uint8Array id", () => {
     const vectors = indexer.encryptRecord({
       id: new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
       title: "Great title!",
-    });
+    })
 
     expect(vectors).toHaveLength(1)
   })

--- a/src/record-indexer.ts
+++ b/src/record-indexer.ts
@@ -1,0 +1,67 @@
+const { initIndexer, encryptRecord } = require("../index.node")
+const { encode, decode } = require("cbor")
+
+/**
+ * A superset of the index mappings defined in the CipherStash [schema definition](https://docs.cipherstash.com/reference/schema-definition.html).
+ */
+interface MappingLike {
+  kind: string
+  [key: string]: unknown
+}
+
+/**
+ * The collection schema used to initialize a RecordIndexer.
+ *
+ * This is base on the CipherStash [schema definition](https://docs.cipherstash.com/reference/schema-definition.html) and includes metadata required for encryption.
+ */
+export type IndexerCollectionSchema = {
+  type: {
+    [key: string]: unknown
+  }
+  indexes: {
+    [key: string]: {
+      mapping: MappingLike
+      prf_key: Buffer
+      prp_key: Buffer
+      index_id: Buffer
+    }
+  }
+}
+
+/**
+ * The terms that can be used to insert a record into the index
+ */
+export type TermVector = Array<{
+  terms: Array<{
+    term: Buffer[]
+    link: Buffer
+  }>
+  indexId: Buffer
+}>
+
+interface RecordLike {
+  id: Buffer | Uint8Array
+  [key: string]: unknown
+}
+
+export class RecordIndexer {
+  private constructor(private handle: unknown) {}
+
+  /**
+   * Initialize as new RecordIndexer based on a collection schema
+   */
+  static init(schema: IndexerCollectionSchema): RecordIndexer {
+    return new RecordIndexer(initIndexer(encode(schema)))
+  }
+
+  /**
+   * Encrypt a record and return an array of terms
+   */
+  encryptRecord(record: RecordLike): TermVector {
+    return decode(encryptRecord(this.handle, encode({
+      ...record,
+      // Ensure that the id is the Buffer base class so it is encoded in CBOR properly
+      id: record.id instanceof Uint8Array ? Buffer.prototype.slice.call(record.id) : record.id
+    })))
+  }
+}


### PR DESCRIPTION
After speaking with @freshtonic he suggested re-using this repo and the npm package for the new `@cipherstash/stash-rs` package.

This PR adds in the `cipherstash_client` calls to create the indexer as well as the cbor encoding / decoding from the JS side. 
It also renames the package to be `@cipherstash/stash-rs` and puts the version back down to `0.1.0`.