### PR TITLE
Support uint64 buffers when encoding range

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cipherstash/stash-rs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Node bindings for the CipherStash Rust client.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -206,4 +206,14 @@ describe("encodeRangeBetween", () => {
   test('correct min and max generated in range', () => {
     expect(ORE.encodeRangeBetween(1, 100)).toEqual({ min: ORE.encode(1), max: ORE.encode(100)})
   })
+
+  test('correct min and max generated in range for u64', () => {
+    let left = Buffer.alloc(8);
+    left.writeBigUInt64BE(1n);
+
+    let right = Buffer.alloc(8);
+    right.writeBigUInt64BE(100n);
+
+    expect(ORE.encodeRangeBetween(left, right)).toEqual({ min: ORE.encode(left), max: ORE.encode(right) })
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,12 +75,12 @@ export interface ORE {
   encode: (input: number | Buffer | string) => OrePlainText
 
 
-  encodeRangeLt: (value: number) => OreRange
-  encodeRangeLte: (value: number) => OreRange
-  encodeRangeGt: (value: number) => OreRange
-  encodeRangeGte: (value: number) => OreRange
-  encodeRangeEq: (value: number) => OreRange
-  encodeRangeBetween: (min: number, max: number) => OreRange
+  encodeRangeLt: (value: number | Buffer) => OreRange
+  encodeRangeLte: (value: number | Buffer) => OreRange
+  encodeRangeGt: (value: number | Buffer) => OreRange
+  encodeRangeGte: (value: number | Buffer) => OreRange
+  encodeRangeEq: (value: number | Buffer) => OreRange
+  encodeRangeBetween: (min: number | Buffer, max: number | Buffer) => OreRange
 
   /**
    * Initialize a new ORE cipher with a key pair (both keys must be 16-byte


### PR DESCRIPTION
At the moment we don't support encoding ranges when passed a BigInt / u64 (as a buffer).
