### PR TITLE
Bump Rust client to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0]
+
+- Upgrade cipherstash-client to 0.2.0
+
+## [0.1.0]
+
+- Rename to @cipherstash/stash-rs
+
 ## [0.5.1]
 
 Add `cargo-cp-artifact` as a dependency so that installation does not silently fail.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-client"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f15019e4dfa895578767bf6c8a99920f3ba3c8a564af055911545a7dd1523936"
+checksum = "8b2e9f2d7bca72979b294ec270b544e08c44913131fa1e38811469c55cab41fb"
 dependencies = [
  "ciborium",
  "conv",
@@ -107,6 +107,7 @@ dependencies = [
  "ore-rs",
  "serde",
  "serde_bytes",
+ "serde_json",
  "thiserror",
  "unicode-normalization",
 ]
@@ -189,6 +190,12 @@ name = "hex-literal"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
+
+[[package]]
+name = "itoa"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "libc"
@@ -506,6 +513,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "ryu"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+
+[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,6 +560,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ path = "native/lib.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cipherstash-client = "0.1.0"
+cipherstash-client = "0.2.0"
 ore-rs = "0.2.0"
 ore-encoding-rs = "0.23.2"
 hex-literal = "0.3.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cipherstash/stash-rs",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Node bindings for the CipherStash Rust client.",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Bumps the Rust client to 0.2.0 to include date time and bigint support.
